### PR TITLE
Change from using `vscode.open` to `openExternal`

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/YuichiNukiyama/vscode-preview-server/issues"
   },
   "engines": {
-    "vscode": "^1.23.0"
+    "vscode": "^1.31.0"
   },
   "categories": [
     "Other"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -65,10 +65,10 @@ export function activate(context: vscode.ExtensionContext) {
         const ignoreDefaultBrowser = options.get("ignoreDefaultBrowser") as boolean;
 
         if (browsers === null && !ignoreDefaultBrowser) {
-            return vscode.commands.executeCommand("vscode.open", uri);
+            return vscode.env.openExternal(uri);
         } else if (browsers !== null  && !ignoreDefaultBrowser) {
             Utility.openBrowser(browsers);
-            return vscode.commands.executeCommand("vscode.open", uri);
+            return vscode.env.openExternal(uri);
         } else if (browsers !== null && ignoreDefaultBrowser) {
             return Utility.openBrowser(browsers);
         } else {
@@ -99,7 +99,7 @@ export function activate(context: vscode.ExtensionContext) {
         }
 
         const uri = vscode.Uri.parse(`http://localhost:${port}`);
-        return vscode.commands.executeCommand("vscode.open", uri);
+        return vscode.env.openExternal(uri);
     });
 
     context.subscriptions.push(vscode.workspace.onDidChangeWorkspaceFolders(() => resumeServer()));


### PR DESCRIPTION
The recently added `vscode.env.openExternal` api is now the preferred way to open http resources in the user's browser. This PR switches from using the `vscode.open` command to use `vscode.env.openExternal `

`vscode.env.openExternal` is generally more compatible across platforms than `vscode.open`
